### PR TITLE
[IOT-343] Added tagging to AWS integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ data "aws_caller_identity" "current" {}
 resource "datadog_integration_aws" "default" {
   account_id = data.aws_caller_identity.current.account_id
   role_name  = local.datadog_integration_role_name
+  host_tags  = var.datadog_tags
 }
-
 
 data "aws_iam_policy_document" "datadog_integration_assume_role" {
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "datadog_tags" {
+  type        = list(string)
+  default     = []
+  description = "Tags (format of key:value) to add to all metrics retrieved from the datadog aws integration"
+}
+
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the bucket"


### PR DESCRIPTION
This PR adds the possibility to add tags to the AWS Integration in DataDog. What this does is add "default tags" to all metrics coming from that account.

This is useful to get metrics even if the AWS resource does not support tags, or people forget to specify tags. (The AWS tags mapping overwrites these account-wide tags).

**Documentation:**
- https://docs.datadoghq.com/tagging/
- https://www.terraform.io/docs/providers/datadog/r/integration_aws.html#host_tags