### PR TITLE
Add permissions for step function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,8 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
       "sns:List*",
       "sns:Publish",
       "sqs:ListQueues",
+      "states:DescribeStateMachine",
+      "states:ListStateMachines",
       "support:*",
       "tag:GetResources",
       "tag:GetTagKeys",


### PR DESCRIPTION
This PR adds the required permissions for DataDog to use the Step Functions integration\

![image](https://user-images.githubusercontent.com/35613489/76867182-76108080-6865-11ea-9175-86fee7cc86e8.png)
