### PR TITLE
Install AWS Forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # terraform-aws-mcaf-datadog
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| datadog | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| tags | A mapping of tags to assign to the bucket | `map(string)` | n/a | yes |
+| api\_key | Datadog API key | `string` | `null` | no |
+| datadog\_tags | Array of tags (in the form key:value) to add to all hosts and metrics | `list(string)` | `[]` | no |
+| install\_log\_forwarder | Set to true to install the Datadog Log Forwarder (requires var.api\_key to be set) | `bool` | `false` | no |
+| log\_forwarder\_name | AWS log forwarder lambda name | `string` | `"datadog-forwarder"` | no |
+| log\_forwarder\_version | AWS log forwarder version to install | `string` | `"latest"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| forwarder\_arn | Datadog log forwarder lambda ARN |

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ data "aws_iam_policy_document" "datadog_integration_assume_role" {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${local.datadog_aws_account_id}:root"]
     }
+
     condition {
       test     = "StringEquals"
       variable = "sts:ExternalId"
@@ -43,11 +44,11 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
       "cloudwatch:Describe*",
       "cloudwatch:Get*",
       "cloudwatch:List*",
-      "codedeploy:List*",
       "codedeploy:BatchGet*",
+      "codedeploy:List*",
       "directconnect:Describe*",
-      "dynamodb:List*",
       "dynamodb:Describe*",
+      "dynamodb:List*",
       "ec2:Describe*",
       "ecs:Describe*",
       "ecs:List*",
@@ -55,34 +56,34 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
       "elasticache:List*",
       "elasticfilesystem:Describe*",
       "elasticloadbalancing:Describe*",
-      "elasticmapreduce:List*",
       "elasticmapreduce:Describe*",
-      "es:ListTags",
-      "es:ListDomainNames",
+      "elasticmapreduce:List*",
       "es:DescribeElasticsearchDomains",
-      "health:DescribeEvents",
-      "health:DescribeEventDetails",
+      "es:ListDomainNames",
+      "es:ListTags",
       "health:DescribeAffectedEntities",
-      "kinesis:List*",
+      "health:DescribeEventDetails",
+      "health:DescribeEvents",
       "kinesis:Describe*",
+      "kinesis:List*",
       "lambda:AddPermission",
       "lambda:GetPolicy",
       "lambda:List*",
       "lambda:RemovePermission",
-      "logs:Get*",
-      "logs:Describe*",
-      "logs:FilterLogEvents",
-      "logs:TestMetricFilter",
-      "logs:PutSubscriptionFilter",
       "logs:DeleteSubscriptionFilter",
+      "logs:Describe*",
       "logs:DescribeSubscriptionFilters",
+      "logs:FilterLogEvents",
+      "logs:Get*",
+      "logs:PutSubscriptionFilter",
+      "logs:TestMetricFilter",
       "rds:Describe*",
       "rds:List*",
       "redshift:DescribeClusters",
       "redshift:DescribeLoggingStatus",
       "route53:List*",
-      "s3:GetBucketLogging",
       "s3:GetBucketLocation",
+      "s3:GetBucketLogging",
       "s3:GetBucketNotification",
       "s3:GetBucketTagging",
       "s3:ListAllMyBuckets",
@@ -98,7 +99,7 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
       "tag:GetTagKeys",
       "tag:GetTagValues",
       "xray:BatchGetTraces",
-      "xray:GetTraceSummaries"
+      "xray:GetTraceSummaries",
     ]
     resources = ["*"]
   }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 locals {
   datadog_integration_role_name = "DatadogAWSIntegrationRole"
   datadog_aws_account_id        = "464622532012"
+
+  install_log_forwarder = var.api_key != null && var.install_log_forwarder ? 1 : 0
 }
 
 data "aws_caller_identity" "current" {}
@@ -113,4 +115,47 @@ module "datadog_integration_role" {
   assume_policy = data.aws_iam_policy_document.datadog_integration_assume_role.json
   role_policy   = data.aws_iam_policy_document.datadog_integration_policy.json
   tags          = var.tags
+}
+
+resource "aws_secretsmanager_secret" "api_key" {
+  count       = local.install_log_forwarder
+  name        = replace("${var.log_forwarder_name}_api_key", "-", "_")
+  description = "Datadog API key used by ${var.log_forwarder_name} lambda"
+}
+
+resource "aws_secretsmanager_secret_version" "api_key" {
+  count         = local.install_log_forwarder
+  secret_id     = aws_secretsmanager_secret.api_key.0.id
+  secret_string = var.api_key
+}
+
+resource "aws_cloudformation_stack" "datadog_forwarder" {
+  count        = local.install_log_forwarder
+  name         = var.log_forwarder_name
+  capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+  on_failure   = "ROLLBACK"
+  template_url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/${var.log_forwarder_version}.yaml"
+  tags         = var.tags
+
+  parameters = {
+    DdApiKey          = "this_value_is_not_used"
+    DdApiKeySecretArn = aws_secretsmanager_secret.api_key.0.arn
+    FunctionName      = var.log_forwarder_name
+  }
+
+  // The DdApiKey parameter has the NoEcho tag set in the cfn template, causing
+  // Terraform to reset the value, so we ignore it.
+  lifecycle {
+    ignore_changes = [
+      parameters["DdApiKey"]
+    ]
+  }
+
+  depends_on = [datadog_integration_aws.default]
+}
+
+resource "datadog_integration_aws_lambda_arn" "default" {
+  count      = local.install_log_forwarder
+  account_id = data.aws_caller_identity.current.account_id
+  lambda_arn = aws_cloudformation_stack.datadog_forwarder.0.outputs["DatadogForwarderArn"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "forwarder_arn" {
+  description = "Datadog log forwarder lambda ARN"
+  value       = tobool(tostring(local.install_log_forwarder)) ? aws_cloudformation_stack.datadog_forwarder.0.outputs["DatadogForwarderArn"] : ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,31 @@
+variable "api_key" {
+  type        = string
+  default     = null
+  description = "Datadog API key"
+}
+
 variable "datadog_tags" {
   type        = list(string)
   default     = []
   description = "Array of tags (in the form key:value) to add to all hosts and metrics"
+}
+
+variable "install_log_forwarder" {
+  type        = bool
+  default     = false
+  description = "Set to true to install the Datadog Log Forwarder (requires var.api_key to be set)"
+}
+
+variable "log_forwarder_name" {
+  type        = string
+  default     = "datadog-forwarder"
+  description = "AWS log forwarder lambda name"
+}
+
+variable "log_forwarder_version" {
+  type        = string
+  default     = "latest"
+  description = "AWS log forwarder version to install"
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
       source = "hashicorp/aws"
@@ -8,4 +7,5 @@ terraform {
       source = "terraform-providers/datadog"
     }
   }
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
As per https://docs.datadoghq.com/serverless/forwarder/ the Datadog Forwarder is an AWS Lambda to ship logs, custom metrics and traces to a Datadog org. See page for more info.

Bear in mind this just sets up the Lambda and does not configure any forwarding, that is done outside of this module at this time and I'll add some docs for this in the future.