### PR TITLE
Add configurable concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | install\_log\_forwarder | Set to true to install the Datadog Log Forwarder (requires var.api\_key to be set) | `bool` | `false` | no |
 | log\_collection\_services | A list of services to collect logs from. Valid values are s3/elb/elbv2/cloudfront/redshift/lambda. | `list(string)` | `null` | no |
 | log\_forwarder\_name | AWS log forwarder lambda name | `string` | `"datadog-forwarder"` | no |
-| log\_forwarder\_reserved\_concurrency | AWS log forwarder reserved concurrency | `number` | `100` | no |
+| log\_forwarder\_reserved\_concurrency | AWS log forwarder reserved concurrency | `number` | `null` | no |
 | log\_forwarder\_version | AWS log forwarder version to install | `string` | `"latest"` | no |
 | site\_url | Define your Datadog Site to send data to. For the Datadog US site, set to datadoghq.com | `string` | `"datadoghq.eu"` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -139,11 +139,12 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
   tags         = var.tags
 
   parameters = {
-    DdApiKey          = "this_value_is_not_used"
-    DdApiKeySecretArn = aws_secretsmanager_secret.api_key.0.arn
-    DdSite            = var.site_url
-    DdTags            = join(",", var.datadog_tags)
-    FunctionName      = var.log_forwarder_name
+    DdApiKey            = "this_value_is_not_used"
+    DdApiKeySecretArn   = aws_secretsmanager_secret.api_key.0.arn
+    DdSite              = var.site_url
+    DdTags              = join(",", var.datadog_tags)
+    FunctionName        = var.log_forwarder_name
+    ReservedConcurrency = var.log_forwarder_reserved_concurrency
   }
 
   // The DdApiKey parameter has the NoEcho tag set in the cfn template, causing

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "log_forwarder_name" {
   description = "AWS log forwarder lambda name"
 }
 
+variable "log_forwarder_reserved_concurrency" {
+  type        = number
+  default     = 100
+  description = "AWS log forwarder reserved concurrency"
+}
+
 variable "log_forwarder_version" {
   type        = string
   default     = "latest"

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "log_forwarder_name" {
 
 variable "log_forwarder_reserved_concurrency" {
   type        = number
-  default     = 100
+  default     = null
   description = "AWS log forwarder reserved concurrency"
 }
 


### PR DESCRIPTION
Make reserved concurrency configurable. Use a default value of 100 concurrent invocations, as is also provided by the template.