### PR TITLE
Implement automatic configuration update check for Datadog Forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 |------|---------|
 | aws | n/a |
 | datadog | n/a |
+| http | n/a |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 locals {
-  datadog_integration_role_name = "DatadogAWSIntegrationRole"
   datadog_aws_account_id        = "464622532012"
+  datadog_forwarder_yaml        = data.http.datadog_forwarder_yaml_url.response_body
+  datadog_integration_role_name = "DatadogAWSIntegrationRole"
 
-  install_log_forwarder  = var.api_key != null && var.install_log_forwarder ? 1 : 0
-  datadog_forwarder_yaml = data.http.datadog_forwarder_yaml_url.response_body
+  install_log_forwarder = var.api_key != null && var.install_log_forwarder ? 1 : 0
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This PR adds the datadog_forwarder_yaml variable to store Datadog forwarder YAML content from an external source, ensuring configuration updates are detected in every Terraform run.

Issue Addressed:
Currently, the `latest` version is not effectively detecting updates, leading to an outdated configuration.