### PR TITLE
feature: Add configuration of the enabled namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.datadog_integration_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datadog_integration_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [datadog_integration_aws_namespace_rules.rules](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_namespace_rules) | data source |
 | [http_http.datadog_forwarder_yaml_url](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ## Inputs
@@ -53,6 +54,7 @@
 | <a name="input_log_forwarder_name"></a> [log\_forwarder\_name](#input\_log\_forwarder\_name) | AWS log forwarder lambda name | `string` | `"datadog-forwarder"` | no |
 | <a name="input_log_forwarder_reserved_concurrency"></a> [log\_forwarder\_reserved\_concurrency](#input\_log\_forwarder\_reserved\_concurrency) | AWS log forwarder reserved concurrency | `number` | `null` | no |
 | <a name="input_log_forwarder_version"></a> [log\_forwarder\_version](#input\_log\_forwarder\_version) | AWS log forwarder version to install | `string` | `"latest"` | no |
+| <a name="input_namespace_rules"></a> [namespace\_rules](#input\_namespace\_rules) | Explicit list of namespaces to enable for metrics collection. If not specific, default namespaces are enabled | `list(string)` | `[]` | no |
 | <a name="input_site_url"></a> [site\_url](#input\_site\_url) | Define your Datadog Site to send data to. For the Datadog US site, set to datadoghq.com | `string` | `"datadoghq.eu"` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "log_forwarder_version" {
   description = "AWS log forwarder version to install"
 }
 
+variable "namespace_rules" {
+  type        = list(string)
+  default     = []
+  description = "Explicit list of namespaces to enable for metrics collection. If not specific, default namespaces are enabled"
+}
+
 variable "site_url" {
   type        = string
   default     = "datadoghq.eu"


### PR DESCRIPTION
This PR adds the configuration of the namespaces. By default, all namespaces are enabled:

<img width="1026" alt="image" src="https://github.com/schubergphilis/terraform-aws-mcaf-datadog/assets/35613489/439f2555-e46b-49cb-8062-3e43b4123eb9">

This is a big impact on the cost (e.g. AWS Cloudwatch `GetAPI` calls). Integrations themselves cannot be configured (see e.g. https://github.com/DataDog/terraform-provider-datadog/issues/200#issuecomment-830490424), we want to configure which metrics to ingest per account.

Build as a explicit enabled list. So if a set of namespaces are given, only those are enabled