### PR TITLE
fix: Dependency fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_integration_role"></a> [datadog\_integration\_role](#module\_datadog\_integration\_role) | github.com/schubergphilis/terraform-aws-mcaf-role | v0.4.0 |
+| <a name="module_datadog_integration_role"></a> [datadog\_integration\_role](#module\_datadog\_integration\_role) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_datadog_integration_role"></a> [datadog\_integration\_role](#module\_datadog\_integration\_role) | github.com/schubergphilis/terraform-aws-mcaf-role | v0.3.2 |
+| <a name="module_datadog_integration_role"></a> [datadog\_integration\_role](#module\_datadog\_integration\_role) | github.com/schubergphilis/terraform-aws-mcaf-role | v0.4.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
 }
 
 module "datadog_integration_role" {
-  source        = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.2"
+  source        = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.4.0"
   name          = local.datadog_integration_role_name
   assume_policy = data.aws_iam_policy_document.datadog_integration_assume_role.json
   create_policy = true

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,8 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
 }
 
 module "datadog_integration_role" {
-  source        = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.4.0"
+  source        = "schubergphilis/mcaf-role/aws"
+  version       = "~> 0.4.0"
   name          = local.datadog_integration_role_name
   assume_policy = data.aws_iam_policy_document.datadog_integration_assume_role.json
   create_policy = true

--- a/main.tf
+++ b/main.tf
@@ -137,8 +137,9 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
 }
 
 module "datadog_integration_role" {
-  source        = "schubergphilis/mcaf-role/aws"
-  version       = "~> 0.4.0"
+  source  = "schubergphilis/mcaf-role/aws"
+  version = "~> 0.4.0"
+
   name          = local.datadog_integration_role_name
   assume_policy = data.aws_iam_policy_document.datadog_integration_assume_role.json
   create_policy = true

--- a/main.tf
+++ b/main.tf
@@ -26,13 +26,13 @@ resource "datadog_integration_aws" "default" {
   excluded_regions                     = var.excluded_regions
   extended_resource_collection_enabled = var.cspm_resource_collection_enabled ? true : var.extended_resource_collection_enabled
   host_tags                            = var.datadog_tags
-  role_name                            = local.datadog_integration_role_name
+  role_name                            = module.datadog_integration_role.name
 }
 
 resource "datadog_integration_aws_tag_filter" "default" {
   for_each = var.metric_tag_filters
 
-  account_id     = data.aws_caller_identity.current.account_id
+  account_id     = datadog_integration_aws.default.account_id
   namespace      = each.key
   tag_filter_str = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "datadog_integration_aws" "default" {
   excluded_regions                     = var.excluded_regions
   extended_resource_collection_enabled = var.cspm_resource_collection_enabled ? true : var.extended_resource_collection_enabled
   host_tags                            = var.datadog_tags
-  role_name                            = module.datadog_integration_role.name
+  role_name                            = local.datadog_integration_role_name
 }
 
 resource "datadog_integration_aws_tag_filter" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@ variable "api_key" {
   type        = string
   default     = null
   description = "Datadog API key"
+  sensitive   = true
 }
 
 variable "cspm_resource_collection_enabled" {
@@ -20,6 +21,12 @@ variable "excluded_regions" {
   type        = list(string)
   default     = []
   description = "List of regions to be excluded from metrics collection in Datadog integration"
+}
+
+variable "extended_resource_collection_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether Datadog collects additional attributes and configuration information about the resources in your AWS account"
 }
 
 variable "install_log_forwarder" {
@@ -84,10 +91,4 @@ variable "site_url" {
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the bucket"
-}
-
-variable "extended_resource_collection_enabled" {
-  type        = bool
-  default     = false
-  description = "Whether Datadog collects additional attributes and configuration information about the resources in your AWS account"
 }


### PR DESCRIPTION
This PR applies multiple fixes, mainly to solve dependency issues we get with spinning up new accounts.

Seen the following:
- In datadog: `Datadog is unable to authenticate with AWS role: DatadogAWSIntegrationRole`
- In Terraform: `Error: error updating aws tag filter from /api/v1/integration/aws/filtering: 400 Bad Request: {"errors":["AWS account XXX does not exist in integration"]}`

Seems all related to dependencies. ~~AWS role needs to be there before the Integration is added~~. (Not true, the Role needs the External ID. So the errors seems to be triggered by the Tag filters) The filter can only be added once the integration is there. With some small tweaks been able to add implicit dependencies.

Other small tweaks:
- Bumped mcaf role module (no functional changes)
- Tweaked some ordering of variables
- Marked the API Key variable explicitly as `sensitive`