### PR TITLE
fix: use correct namespace list for validation, exclude integration policy permissions from resource collection policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@
 | [aws_iam_policy_document.datadog_integration_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datadog_integration_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datadog_resource_collection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [datadog_integration_aws_available_namespaces.namespaces](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_available_namespaces) | data source |
 | [datadog_integration_aws_iam_permissions.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions) | data source |
 | [datadog_integration_aws_iam_permissions_resource_collection.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions_resource_collection) | data source |
-| [datadog_integration_aws_namespace_rules.rules](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_namespace_rules) | data source |
 | [http_http.datadog_forwarder_yaml_url](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@
 | [aws_iam_policy_document.datadog_integration_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datadog_resource_collection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [datadog_integration_aws_available_namespaces.namespaces](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_available_namespaces) | data source |
-| [datadog_integration_aws_iam_permissions.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions) | data source |
 | [datadog_integration_aws_iam_permissions_resource_collection.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions_resource_collection) | data source |
+| [datadog_integration_aws_iam_permissions_standard.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions_standard) | data source |
 | [http_http.datadog_forwarder_yaml_url](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@
 | [aws_iam_policy_document.datadog_integration_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datadog_resource_collection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [datadog_integration_aws_available_namespaces.namespaces](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_available_namespaces) | data source |
-| [datadog_integration_aws_iam_permissions_resource_collection.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions_resource_collection) | data source |
 | [datadog_integration_aws_iam_permissions_standard.default](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/integration_aws_iam_permissions_standard) | data source |
 | [http_http.datadog_forwarder_yaml_url](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
     namespace if !contains(var.namespace_rules, namespace)
   ]
 
-  exclusive_resource_collection_policies = setsubstract(
+  exclusive_resource_collection_policies = setsubtract(
     toset(data.datadog_integration_aws_iam_permissions_resource_collection.default.iam_permissions),
     toset(data.datadog_integration_aws_iam_permissions.default.iam_permissions)
   )

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
 
   exclusive_resource_collection_permissions = setsubtract(
     toset(data.datadog_integration_aws_iam_permissions_resource_collection.default.iam_permissions),
-    toset(data.datadog_integration_aws_iam_permissions.default.iam_permissions)
+    toset(data.datadog_integration_aws_iam_permissions_standard.default.iam_permissions)
   )
 }
 
@@ -107,14 +107,14 @@ data "aws_iam_policy_document" "datadog_integration_assume_role" {
   }
 }
 
-data "datadog_integration_aws_iam_permissions" "default" {}
+data "datadog_integration_aws_iam_permissions_standard" "default" {}
 
 data "datadog_integration_aws_iam_permissions_resource_collection" "default" {}
 
 data "aws_iam_policy_document" "datadog_integration_policy" {
   #https://docs.datadoghq.com/integrations/amazon_web_services/#aws-integration-iam-policy
   statement {
-    actions   = data.datadog_integration_aws_iam_permissions.default.iam_permissions
+    actions   = data.datadog_integration_aws_iam_permissions_standard.default.iam_permissions
     resources = ["*"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
     namespace if !contains(var.namespace_rules, namespace)
   ]
 
-  exclusive_resource_collection_policies = setsubtract(
+  exclusive_resource_collection_permissions = setsubtract(
     toset(data.datadog_integration_aws_iam_permissions_resource_collection.default.iam_permissions),
     toset(data.datadog_integration_aws_iam_permissions.default.iam_permissions)
   )
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
 data "aws_iam_policy_document" "datadog_resource_collection_policy" {
   #https://docs.datadoghq.com/integrations/amazon_web_services/#aws-resource-collection-iam-policy
   statement {
-    actions   = local.exclusive_resource_collection_policies
+    actions   = local.exclusive_resource_collection_permissions
     resources = ["*"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,15 +6,20 @@ locals {
   datadog_resource_collection_enabled     = var.cspm_resource_collection_enabled || var.extended_resource_collection_enabled ? true : false
 
   excluded_namespaces = length(var.namespace_rules) == 0 ? null : [
-    for namespace in toset(data.datadog_integration_aws_namespace_rules.rules.namespace_rules) :
+    for namespace in toset(data.datadog_integration_aws_available_namespaces.namespaces.aws_namespaces) :
     namespace if !contains(var.namespace_rules, namespace)
   ]
+
+  exclusive_resource_collection_policies = setsubstract(
+    toset(data.datadog_integration_aws_iam_permissions_resource_collection.default.iam_permissions),
+    toset(data.datadog_integration_aws_iam_permissions.default.iam_permissions)
+  )
 }
 
-check "namespace_rules" {
+check "namespaces" {
   assert {
-    condition     = alltrue([for namespace in var.namespace_rules : contains(data.datadog_integration_aws_namespace_rules.rules.namespace_rules, namespace)])
-    error_message = "One or more provided namespaces in var.namespace_rules are invalid. Use data.datadog_integration_aws_namespace_rules to get the list of valid namespaces."
+    condition     = alltrue([for namespace in var.namespace_rules : contains(data.datadog_integration_aws_available_namespaces.namespaces.aws_namespaces, namespace)])
+    error_message = "One or more provided namespaces in var.namespace_rules are invalid. Use data.datadog_integration_aws_available_namespaces to get the list of valid namespaces."
   }
 }
 
@@ -24,7 +29,7 @@ data "http" "datadog_forwarder_yaml_url" {
   url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/${var.log_forwarder_version}.yaml"
 }
 
-data "datadog_integration_aws_namespace_rules" "rules" {}
+data "datadog_integration_aws_available_namespaces" "namespaces" {}
 
 resource "datadog_integration_aws_external_id" "default" {}
 
@@ -117,7 +122,7 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
 data "aws_iam_policy_document" "datadog_resource_collection_policy" {
   #https://docs.datadoghq.com/integrations/amazon_web_services/#aws-resource-collection-iam-policy
   statement {
-    actions   = data.datadog_integration_aws_iam_permissions_resource_collection.default.iam_permissions
+    actions   = local.exclusive_resource_collection_policies
     resources = ["*"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,6 @@ locals {
     for namespace in toset(data.datadog_integration_aws_available_namespaces.namespaces.aws_namespaces) :
     namespace if !contains(var.namespace_rules, namespace)
   ]
-
-  exclusive_resource_collection_permissions = setsubtract(
-    toset(data.datadog_integration_aws_iam_permissions_resource_collection.default.iam_permissions),
-    toset(data.datadog_integration_aws_iam_permissions_standard.default.iam_permissions)
-  )
 }
 
 check "namespaces" {
@@ -109,8 +104,6 @@ data "aws_iam_policy_document" "datadog_integration_assume_role" {
 
 data "datadog_integration_aws_iam_permissions_standard" "default" {}
 
-data "datadog_integration_aws_iam_permissions_resource_collection" "default" {}
-
 data "aws_iam_policy_document" "datadog_integration_policy" {
   #https://docs.datadoghq.com/integrations/amazon_web_services/#aws-integration-iam-policy
   statement {
@@ -121,8 +114,73 @@ data "aws_iam_policy_document" "datadog_integration_policy" {
 
 data "aws_iam_policy_document" "datadog_resource_collection_policy" {
   #https://docs.datadoghq.com/integrations/amazon_web_services/#aws-resource-collection-iam-policy
+  #checkov:skip=CKV_AWS_111: Resource wildcard cannot be scoped because it's not known beforehand which exact resources datadog need to be able to scrape
+  #checkov:skip=CKV_AWS_356: Policy cannot be more scoped down, this is the recommended policy by datadog
   statement {
-    actions   = local.exclusive_resource_collection_permissions
+    actions = [
+      "amplify:ListApps",
+      "amplify:ListArtifacts",
+      "amplify:ListBackendEnvironments",
+      "amplify:ListBranches",
+      "amplify:ListDomainAssociations",
+      "amplify:ListJobs",
+      "amplify:ListWebhooks",
+      "appstream:DescribeAppBlockBuilders",
+      "appstream:DescribeAppBlocks",
+      "appstream:DescribeApplications",
+      "appstream:DescribeFleets",
+      "appstream:DescribeImageBuilders",
+      "appstream:DescribeImages",
+      "appstream:DescribeStacks",
+      "batch:DescribeJobQueues",
+      "batch:DescribeSchedulingPolicies",
+      "batch:ListSchedulingPolicies",
+      "deadline:GetBudget",
+      "deadline:GetLicenseEndpoint",
+      "deadline:GetQueue",
+      "deadline:ListBudgets",
+      "deadline:ListFarms",
+      "deadline:ListFleets",
+      "deadline:ListLicenseEndpoints",
+      "deadline:ListMonitors",
+      "deadline:ListQueues",
+      "deadline:ListWorkers",
+      "identitystore:DescribeGroup",
+      "identitystore:DescribeGroupMembership",
+      "imagebuilder:GetContainerRecipe",
+      "imagebuilder:GetDistributionConfiguration",
+      "imagebuilder:GetImageRecipe",
+      "imagebuilder:GetInfrastructureConfiguration",
+      "imagebuilder:GetLifecyclePolicy",
+      "imagebuilder:GetWorkflow",
+      "imagebuilder:ListComponents",
+      "imagebuilder:ListContainerRecipes",
+      "imagebuilder:ListDistributionConfigurations",
+      "imagebuilder:ListImagePipelines",
+      "imagebuilder:ListImageRecipes",
+      "imagebuilder:ListImages",
+      "imagebuilder:ListInfrastructureConfigurations",
+      "imagebuilder:ListLifecyclePolicies",
+      "imagebuilder:ListWorkflows",
+      "mobiletargeting:GetApps",
+      "mobiletargeting:GetCampaigns",
+      "mobiletargeting:GetChannels",
+      "mobiletargeting:GetEventStream",
+      "mobiletargeting:GetRecommenderConfigurations",
+      "mobiletargeting:GetSegments",
+      "mobiletargeting:ListJourneys",
+      "mobiletargeting:ListTemplates",
+      "sms-voice:DescribeConfigurationSets",
+      "sms-voice:DescribeOptOutLists",
+      "sms-voice:DescribePhoneNumbers",
+      "sms-voice:DescribePools",
+      "sms-voice:DescribeProtectConfigurations",
+      "sms-voice:DescribeRegistrationAttachments",
+      "sms-voice:DescribeRegistrations",
+      "sms-voice:DescribeSenderIds",
+      "sms-voice:DescribeVerifiedDestinationNumbers",
+      "social-messaging:ListLinkedWhatsAppBusinessAccounts"
+    ]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
**:hammer_and_wrench: Summary**

Fixes bugs present in 1.0.0 release.

1. Wrong data source was used to validate list of namespace enabled for metrics
2. Resource collection policy exceeds AWS limits. Reverted to previous manual list and improvement on this will be implemented in future update
3. Standard integration policy used a data source that included permissions needed for resource collection. That is now replaced with standard integration permissions list.

**:rocket: Motivation**

Doesn't apply if extended resource collection is enabled or if list of namespaces is set.

**:pencil: Additional Information**
n/a
